### PR TITLE
extend skill.json spec

### DIFF
--- a/docs/skill_json.md
+++ b/docs/skill_json.md
@@ -6,31 +6,40 @@ This file contains metadata about the skill and is all you need to submit a skil
 
 ```javascript
 {
-  "name": "Wolfram Alpha",
-  "description": "Get information from Wolfram Alpha",
-  "skillname": "skill-wolfie",
-  "authorname": "JarbasSkills",
-  "url": "https://github.com/JarbasSkills/skill-wolfie",
-  "branch": "v0.1",
-  "desktopFile": false,
-  "systemDeps": false,
-  "download_url": "https://github.com/JarbasSkills/skill-wolfie/archive/v0.1.tar.gz",
-  "examples": [
-    "ask the wolf what is the speed of light",
-    "How tall is Mount Everest?",
-    "When was The Rocky Horror Picture Show released?",
-    "What is Madonna's real name?",
-    "What's 18 times 4?",
-    "How many inches in a meter?"
-  ],
-  "lang": "en-us",
-  "lang_support": {
-    "pt-pt": {
-      "name": "Wolfram Alpha",
-      "description": "...",
-      "examples": [...]
+    "name": "Wolfram Alpha",
+    "description": "Get information from Wolfram Alpha",
+    "skillname": "skill-wolfie",
+    "authorname": "JarbasSkills",
+    "url": "https://github.com/JarbasSkills/skill-wolfie",
+    "branch": "v0.1",
+    "desktopFile": false,
+    "systemDeps": false,
+    "download_url": "https://github.com/JarbasSkills/skill-wolfie/archive/v0.1.tar.gz",
+    "examples": [
+        "ask the wolf what is the speed of light",
+        "How tall is Mount Everest?",
+        "When was The Rocky Horror Picture Show released?",
+        "What is Madonna's real name?",
+        "What's 18 times 4?",
+        "How many inches in a meter?"
+    ],
+    "lang": "en-us",
+    "lang_support": {
+        "pt-pt": {
+          "name": "Wolfram Alpha",
+          "description": "...",
+          "examples": [...]
+        }
+    },
+    "requirements": {
+      "qt_version": "5",
+      "phal": ["phal-plugin-X"],
+      "admin": ["phal-admin-plugin-X"],
+      "ocp": ["ocp-plugin-X"],
+      "utterance": ["utterance-transformer.plugin-X"],
+      "audio": ["audio-transformer-plugin-X"],
+      "playback": ["audio-player-plugin-X"]      
     }
-  }
 }
 ```
 
@@ -50,3 +59,4 @@ On the JSON file:
 * `examples` is a list of example utterances that this skill should handle
 * `lang` is the language the `skill.json` and `README.md` files are written in
 * `lang_support` is a dict of other supported languages to translated skill `name`, `description`, and `examples`. Missing fields will default to top-level fields
+* `requirements` is a dict specifying other ovos platform requirements, in distributed setups such as docker plugins live in different services and can not be specified as regular python packages


### PR DESCRIPTION
extend skill.json spec to allow specifying more complex requirements

`requirements` is a dict specifying other ovos platform requirements, in distributed setups such as docker plugins live in different services and can not be specified as regular python packages

```javascript
"requirements": {
      "qt_version": "5",
      "phal": ["phal-plugin-X"],
      "admin": ["phal-admin-plugin-X"],
      "ocp": ["ocp-plugin-X"],
      "utterance": ["utterance-transformer.plugin-X"],
      "audio": ["audio-transformer-plugin-X"],
      "playback": ["audio-player-plugin-X"]      
}
```

example usages are bandcamp/deezer/news needing their respective OCP extractors, skills that need Oauth will require the companion PHAL plugin, hardware control skills will also require phal or possibly admin plugins. some skills such as spotify (WIP) and peerflix (WIP) may also require dedicated audio service players

this also accounts for https://github.com/OpenVoiceOS/ovos-core/pull/163 where skills may start depending on message.context from those plugins