### PR TITLE
Add `swig` to installation instructions

### DIFF
--- a/docs/install_ovos_core.md
+++ b/docs/install_ovos_core.md
@@ -32,7 +32,7 @@ python -m venv .venv
 ```
 Update `pip` and install `wheel`
 
-`pip install -U pip wheel`
+`pip install -U pip wheel swig`
 
 ## From PyPi
 


### PR DESCRIPTION
Needed this to build the `pocketsphinx` dependency.