### PR TITLE
Update 010-hardware.md

### DIFF
--- a/docs/010-hardware.md
+++ b/docs/010-hardware.md
@@ -3,8 +3,8 @@
 OVOS has been confirmed to run on several devices, and more to come.
 
 - RPI3b / RPI3b+  (Headless only)
-  - [Headless Image](https://ovosimages/ziggyai.online/raspbian/development/)
-  - [Mark 1 image](https://ovosimages/ziggyai/online/mark1)
+  - [Headless Image](https://ovosimages.ziggyai.online/raspbian/development/)
+  - [Mark 1 image](https://ovosimages.ziggyai.online/mark1)
     - [Mycroft Mark 1 device.](https://github.com/MycroftAI/hardware-mycroft-mark-1)  ([ovos-PHAL-plugin-mk1 plugin required](https://github.com/OpenVoiceOS/ovos-PHAL-plugin-mk1))
 - RPI4  (GUI and Headless)
   - [Buildroot GUI image](https://drive.google.com/file/d/1PUtNXfZ5jMUlVAgyN-KXPdVdX6r51eBw/view?usp=share_link)


### PR DESCRIPTION
Fixed errors in links to the Mark 1 and Headless images.